### PR TITLE
Cleanup the trailing space

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
 
 arch:
-  - arm64 
+  - arm64
   - x86
 
 addons:
@@ -13,10 +13,10 @@ addons:
   hosts:
     - node2
 
-language: 
+language:
   - c
-  
-script:  
+
+script:
   - cd ..
   - sudo apt-get install libboost-dev
 
@@ -26,12 +26,12 @@ script:
   - sudo ./configure
   - sudo make -j16
   - sudo make install
-  
+
   - cd ../
   - wget https://ftp.pcre.org/pub/pcre/pcre-8.41.tar.gz
   - tar -zxvf pcre-8.41.tar.gz
   - sudo cp -rf ./pcre-8.41 ./hyperscan/pcre
-  
+
   - cd ./hyperscan
   - rm -rf build
   - mkdir build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,7 @@ CMAKE_DEPENDENT_OPTION(DUMP_SUPPORT "Dump code support; normally on, except in r
 
 CMAKE_DEPENDENT_OPTION(DISABLE_ASSERTS "Disable assert(); Asserts are enabled in debug builds, disabled in release builds" OFF "NOT RELEASE_BUILD" ON)
 
-option(BUILD_AVX512 "Experimental: support avx512 in the fat runtime" 
+option(BUILD_AVX512 "Experimental: support avx512 in the fat runtime"
     OFF)
 
 option(WINDOWS_ICC "Use Intel C++ Compiler on Windows, default off, requires ICC to be set in project" OFF)
@@ -182,7 +182,7 @@ else()
         # generic, which isn't very good in some cases. march=native looks at
         # cpuid info and then chooses the best microarch it can (and replaces
         # the flag), so use that for tune.
-        
+
         if (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|i386")
             # arg1 might exist if using ccache
             string (STRIP "${CMAKE_C_COMPILER_ARG1}" CC_ARG1)
@@ -205,7 +205,7 @@ else()
             endif()
         endif()
 
-        if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|AARCH64") 
+        if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|AARCH64")
             set (EXEC_ARGS ${CC_ARG1} -c -Q --help=target -march=armv8-a -mtune=armv8-a)
         endif()
         set(TUNE_FLAG ${GNUCC_ARCH})
@@ -578,7 +578,7 @@ if (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|i386")
     ragelmaker(src/parser/Parser.rl)
 endif()
 
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|AARCH64") 
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|AARCH64")
     ragelcopyer(src/parser/Parser.rl)
 endif()
 
@@ -592,7 +592,7 @@ if (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|i386")
     ragelmaker(src/parser/control_verbs.rl)
 endif()
 
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|AARCH64") 
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|AARCH64")
     ragelcopyer(src/parser/control_verbs.rl)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -22,22 +22,22 @@ project repository.
 
 # Versioning
 
-The `master` branch on Github/kunpengcompute will always contain the most recent 
-release of Intel Hyperscan. 
+The `master` branch on Github/kunpengcompute will always contain the most recent
+release of Intel Hyperscan.
 
-The `aarch64` branch on Github/kunpengcompute will always contain the most recent 
+The `aarch64` branch on Github/kunpengcompute will always contain the most recent
 release that supports the aarch64 architecture. The aarch64 branch was developed
 based on Intel hyperscan 5.2.1. Each version released to `aarch64` branch goes through
 QA and testing before it is released; if you're a user of aarch64, rather than a developer,
 this is the version you should be using.
 
 # Porting
-Perform platform-specific different operations, including compilation options, 
+Perform platform-specific different operations, including compilation options,
 detection specific header files, SIMD instruction judgment, and so on.
 
 # Optimization
-Improve the Kunpeng platform by using the NEON instructions, inline assembly, 
-data alignment, instruction alignment, memory data prefetching, static branch 
+Improve the Kunpeng platform by using the NEON instructions, inline assembly,
+data alignment, instruction alignment, memory data prefetching, static branch
 prediction, code structure optimization, etc.
 
 # Get Involved
@@ -47,7 +47,7 @@ The official homepage for Hyperscan is at [www.hyperscan.io](https://www.hypersc
 `master` branch
 
 If you have questions or comments, we encourage you to [join the mailing list]
-(https://lists.01.org/mailman/listinfo/hyperscan). To file a bug, you can send an email 
+(https://lists.01.org/mailman/listinfo/hyperscan). To file a bug, you can send an email
 to the list, or create an issue on Github.
 
 If you wish to contact the Hyperscan team at Intel directly, without posting
@@ -58,5 +58,5 @@ publicly to the mailing list, send an email to
 
 If you have questions or comments, we encourage you to create an issue on Github.
 
-If you wish to contact the Huawei team directly, you can send an email to 
+If you wish to contact the Huawei team directly, you can send an email to
 kunpengcompute@huawei.com.

--- a/ThirdPartyNotice.md
+++ b/ThirdPartyNotice.md
@@ -1,12 +1,12 @@
 # THIRD PARTY OPEN SOURCE SOFTWARE NOTICE
-Please note we provide an open source software notice for the third party open source software along with this software and/or this software component contributed by Huawei (in the following just “this SOFTWARE”). The open source software licenses are granted by the respective right holders. 
+Please note we provide an open source software notice for the third party open source software along with this software and/or this software component contributed by Huawei (in the following just “this SOFTWARE”). The open source software licenses are granted by the respective right holders.
 
-# Warranty Disclaimer   
+# Warranty Disclaimer
 THE OPEN SOURCE SOFTWARE IN THIS SOFTWARE IS DISTRIBUTED IN THE HOPE THAT IT WILL BE USEFUL, BUT WITHOUT ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. SEE THE APPLICABLE LICENSES FOR MORE DETAILS.
 
-# Copyright Notice and License Texts 
-Software: hyperscan 5.2.1  
-Copyright notice: 
+# Copyright Notice and License Texts
+Software: hyperscan 5.2.1
+Copyright notice:
 
 Copyright (c) 2015-2019, Intel Corporation
 Copyright (c) 2015-2017, Intel Corporation
@@ -35,7 +35,7 @@ Copyright (c) 2004-2006 Intel Corporation - All Rights Reserved
 Copyright (c) 2019, Intel Corporation
 
 
-License: BSD 3-Clause License 
+License: BSD 3-Clause License
 
 Copyright (c) <YEAR>, <OWNER>
 All rights reserved.

--- a/src/fdr/fdr.c
+++ b/src/fdr/fdr.c
@@ -133,7 +133,7 @@ u64a andn(const u32 a, const u8 *b) {
                          : "=r"(r)
                          : "r"(a), "m"(*(const u32 *)b)
                          : "w0"
-    );	
+    );
 #else
     r = unaligned_load_u32(b) & ~a;
 #endif

--- a/src/util/cpuid_inline.h
+++ b/src/util/cpuid_inline.h
@@ -96,7 +96,7 @@ void cpuid(unsigned int op, unsigned int leaf, unsigned int *eax,
 #define CPUID_XCR0_AVX512                                                      \
     (CPUID_XCR0_OPMASK | CPUID_XCR0_ZMM_Hi256 | CPUID_XCR0_Hi16_ZMM)
 
-#if defined(__x86_64__) 
+#if defined(__x86_64__)
 static inline
 u64a xgetbv(u32 op) {
 #if defined(_WIN32) || defined(__INTEL_COMPILER)

--- a/tools/hscollider/CMakeLists.txt
+++ b/tools/hscollider/CMakeLists.txt
@@ -26,7 +26,7 @@ if (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|i386")
     ragelmaker(ColliderCorporaParser.rl)
 endif()
 
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|AARCH64") 
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|AARCH64")
     ragelcopyer(ColliderCorporaParser.rl)
 endif()
 

--- a/unit/internal/simd_utils.cpp
+++ b/unit/internal/simd_utils.cpp
@@ -40,7 +40,7 @@ using namespace ue2;
 namespace {
 
 // Switch one bit on in a bitmask.
-template <class Mask> 
+template <class Mask>
 Mask setbit(unsigned int bit) {
     union {
         Mask simd;
@@ -148,7 +148,7 @@ m256 simd_lshift64(const m256 &a, unsigned i) { return lshift64_m256(a, i); }
 m384 simd_lshift64(const m384 &a, unsigned i) { return lshift64_m384(a, i); }
 m512 simd_lshift64(const m512 &a, unsigned i) { return lshift64_m512(a, i); }
 
-template <typename T> 
+template <typename T>
 class SimdUtilsTest : public testing::Test {
     // empty
 };

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -15,7 +15,7 @@ if (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|i386")
     ragelmaker(ExpressionParser.rl)
 endif()
 
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|AARCH64") 
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|AARCH64")
     ragelcopyer(ExpressionParser.rl)
 endif()
 


### PR DESCRIPTION
These spaces will cause the build breaks in rpm build [1], so we cleanup all these spaces in this patch.

[1] https://gitee.com/src-openeuler/hyperscan